### PR TITLE
Fix exact match text comparison not working when not lowercased

### DIFF
--- a/Sources/LocoBuddy/Commands/Search.swift
+++ b/Sources/LocoBuddy/Commands/Search.swift
@@ -42,7 +42,7 @@ struct Search: ParsableCommand {
         let options = keyedEntries
             .filter { entry in
                 switch match {
-                case .exact: return entry.key.lowercased() == text
+                case .exact: return entry.key.lowercased() == text.lowercased()
                 case .contains: return entry.key.lowercased().contains(text.lowercased())
                 case .containsAll:
                     let textWords = text.split(separator: " ")


### PR DESCRIPTION
Fixes the exact match command not finding any matches.

For example: 

```
LocoBuddy search --language "German" --match exact "Read only"
```

Would previously return no results because the key is lowercased to "read only", but the search term is not leading to `"read only"` compared against `"Read only"`.